### PR TITLE
Fix since it is not getting the latest ector ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.6",
-    "ector": "^0.1.7",
+    "ector": "*",
     "file-concept-network": "^0.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to this bug #7 (possibly fixed here https://github.com/parmentf/node-ector/issues/4) the dependency was not changed so I think it should be changed in order to get the latest version.
